### PR TITLE
Add new external section w/ link to online courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,10 @@ If you like the project, do not forget to `put star ★` and follow me on GitHub
 * [xcode-shop.com](https://xcode-shop.com) - I am sale some source of my apps & elements
 * [codecanyon.net](https://codecanyon.net/category/mobile/ios) - App templates from developers
 
+## External
+
+* [SwiftUI Online Courses](https://classpert.com/swiftui) - List of SwiftUI online courses from top e-learning platforms, curated by Classpert
+
 ## License
 
 `awesome-ios-ui` is released under the MIT license. Check `LICENSE.md` for details.

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ If you like the project, do not forget to `put star ★` and follow me on GitHub
 * [xcode-shop.com](https://xcode-shop.com) - I am sale some source of my apps & elements
 * [codecanyon.net](https://codecanyon.net/category/mobile/ios) - App templates from developers
 
-## External
+### External
 
 * [SwiftUI Online Courses](https://classpert.com/swiftui) - List of SwiftUI online courses from top e-learning platforms, curated by Classpert
 


### PR DESCRIPTION
This commit adds a new external section and a new link to a curated list of SwiftUI online courses from top e-learning platforms (Udemy, Skillshare, Pluralsight). It's curated by Classpert, an online course search engine.